### PR TITLE
2.1 develop

### DIFF
--- a/app/code/Magento/Catalog/Model/ImageExtractor.php
+++ b/app/code/Magento/Catalog/Model/ImageExtractor.php
@@ -5,10 +5,11 @@
  */
 namespace Magento\Catalog\Model;
 
-use Magento\Catalog\Model\Product\Attribute\Backend\Media\ImageEntryConverter;
 use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product\Attribute\Backend\Media\ImageEntryConverter;
+use Magento\Framework\View\Xsd\Media\TypeDataExtractorInterface;
 
-class ImageExtractor implements \Magento\Framework\View\Xsd\Media\TypeDataExtractorInterface
+class ImageExtractor implements TypeDataExtractorInterface
 {
     /**
      * Extract configuration data of images from the DOM structure
@@ -55,6 +56,7 @@ class ImageExtractor implements \Magento\Framework\View\Xsd\Media\TypeDataExtrac
         $backgroundArray = [];
         if (preg_match($pattern, $backgroundString, $backgroundArray)) {
             array_shift($backgroundArray);
+            $backgroundArray = array_map('intval', $backgroundArray);
         }
         return $backgroundArray;
     }

--- a/app/code/Magento/Catalog/Model/ImageExtractor.php
+++ b/app/code/Magento/Catalog/Model/ImageExtractor.php
@@ -31,8 +31,11 @@ class ImageExtractor implements TypeDataExtractorInterface
                 if ($attribute->nodeType != XML_ELEMENT_NODE) {
                     continue;
                 }
-                if ($attribute->tagName == 'background') {
+                $attributeTagName = $attribute->tagName;
+                if ($attributeTagName === 'background') {
                     $nodeValue = $this->processImageBackground($attribute->nodeValue);
+                } elseif ($attributeTagName === 'width' || $attributeTagName === 'height') {
+                    $nodeValue = intval($attribute->nodeValue);
                 } else {
                     $nodeValue = $attribute->nodeValue;
                 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ImageExtractorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ImageExtractorTest.php
@@ -23,7 +23,7 @@ class ImageExtractorTest extends \PHPUnit_Framework_TestCase
     public function testProcess()
     {
         $expectedArray = include(__DIR__ . '/_files/converted_view.php');
-        $this->assertEquals($expectedArray, $this->model->process($this->getDomElement(), 'media'));
+        $this->assertSame($expectedArray, $this->model->process($this->getDomElement(), 'media'));
     }
 
     /**

--- a/app/code/Magento/Cms/Model/ResourceModel/Block.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block.php
@@ -183,7 +183,7 @@ class Block extends AbstractDb
         $entityMetadata = $this->metadataPool->getMetadata(BlockInterface::class);
         $linkField = $entityMetadata->getLinkField();
 
-        if ($this->_storeManager->hasSingleStore()) {
+        if ($this->_storeManager->isSingleStoreMode()) {
             $stores = [Store::DEFAULT_STORE_ID];
         } else {
             $stores = (array)$object->getData('store_id');
@@ -230,7 +230,7 @@ class Block extends AbstractDb
                 'cbs.' . $linkField . ' = cb.' . $linkField,
                 []
             )
-            ->where('cb.' . $entityMetadata->getIdentifierField()  . ' = :block_id');
+            ->where('cb.' . $entityMetadata->getIdentifierField() . ' = :block_id');
 
         return $connection->fetchCol($select, ['block_id' => (int)$id]);
     }

--- a/app/code/Magento/Cms/Model/ResourceModel/Block.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block.php
@@ -186,7 +186,7 @@ class Block extends AbstractDb
         if ($this->_storeManager->hasSingleStore()) {
             $stores = [Store::DEFAULT_STORE_ID];
         } else {
-            $stores = (array)$object->getData('stores');
+            $stores = (array)$object->getData('store_id');
         }
 
         $select = $this->getConnection()->select()

--- a/app/code/Magento/Customer/etc/webapi.xml
+++ b/app/code/Magento/Customer/etc/webapi.xml
@@ -188,6 +188,12 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+    <route url="/V1/customers/resetPassword" method="POST">
+        <service class="Magento\Customer\Api\AccountManagementInterface" method="resetPassword"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
     <route url="/V1/customers/:customerId/confirm" method="GET">
         <service class="Magento\Customer\Api\AccountManagementInterface" method="getConfirmationStatus"/>
         <resources>

--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -318,7 +318,7 @@
     </zip>
     <zip countryCode="NL">
         <codes>
-            <code id="pattern_1" active="true" example="1234 AB">^[0-9]{4}\s[a-zA-Z]{2}$</code>
+            <code id="pattern_1" active="true" example="1234 AB/1234AB">^[1-9][0-9]{3}\s?[a-zA-Z]{2}$</code>
         </codes>
     </zip>
     <zip countryCode="NO">


### PR DESCRIPTION
Solve problem adding product from wishlist when these require more of one unit

Description

Problem encountered when obtaining the qty parameter. In this case, the qty is sent by mail and query string. The solution is to verify if the qty param is sent by post and take this value; in another case obtain param from querystring.

Fixed Issues (if relevant)

magento/magento2#PR#9155:Adding product from wishlist not adding to cart showing warning message.
Manual testing scenarios

1.add a simple product from admin with Minimum Qty Allowed in Shopping Cart 10
2.login in front end
3.Add product to wishlist
4.Click on wishlist
5.Try to add product with qty 1 it will redirect to product detail page
6.try to add product with 10 qty in the same page..

Contribution checklist

[X] Pull request has a meaningful description of its purpose
[X]  All commits are accompanied by meaningful commit messages
[ ] All new or changed code is covered with unit/integration tests (if applicable)
[ ] All automated tests passed successfully (all builds on Travis CI are green)

